### PR TITLE
Update lvs_netgen.tcl

### DIFF
--- a/mag/tcl/lvs_netgen.tcl
+++ b/mag/tcl/lvs_netgen.tcl
@@ -2,7 +2,7 @@ set layout [readnet spice $project.lvs.spice]
 set source [readnet spice /dev/null]
 readnet spice $::env(PDK_ROOT)/$::env(PDK)/libs.ref/sky130_fd_sc_hd/spice/sky130_fd_sc_hd.spice $source
 # add any spice files of your analog blocks:
-readnet spice ../xschem/simulation/inverter.spice $source
+readnet spice ../xschem/simulation/$project.spice $source
 # top level GL verilog
 readnet verilog ../src/project.v $source
 lvs "$layout $project" "$source $project" $::env(PDK_ROOT)/sky130A/libs.tech/netgen/sky130A_setup.tcl lvs.report -blackbox


### PR DESCRIPTION
Changed hardcoded spice.sim to $project.sim so if a user tries to do LVS with a cell and spice file named anything other than "inverter" the netgen script will run properly instead of trying to use inverter.spice for everything and producing confusing errors.